### PR TITLE
Refactor MarkdownEditor tests

### DIFF
--- a/packages/MarkdownEditor-Tests.package/MarkdownEditorTests.class/instance/closeMarkdownEditorWindows.st
+++ b/packages/MarkdownEditor-Tests.package/MarkdownEditorTests.class/instance/closeMarkdownEditorWindows.st
@@ -1,4 +1,0 @@
-tests - utilities
-closeMarkdownEditorWindows
-
-	self markdownWindows do: [:window | window delete]

--- a/packages/MarkdownEditor-Tests.package/MarkdownEditorTests.class/instance/markdownWindows.st
+++ b/packages/MarkdownEditor-Tests.package/MarkdownEditorTests.class/instance/markdownWindows.st
@@ -1,6 +1,0 @@
-tests - utilities
-markdownWindows
-
-	^ SystemWindow
-		windowsIn: World
-		satisfying: [:window | window label = 'Markdown Editor']

--- a/packages/MarkdownEditor-Tests.package/MarkdownEditorTests.class/instance/setUp.st
+++ b/packages/MarkdownEditor-Tests.package/MarkdownEditorTests.class/instance/setUp.st
@@ -1,4 +1,5 @@
 running
 setUp
 
+	window := MarkdownEditor open.
 	toolbuilder := ToolBuilder default

--- a/packages/MarkdownEditor-Tests.package/MarkdownEditorTests.class/instance/tearDown.st
+++ b/packages/MarkdownEditor-Tests.package/MarkdownEditorTests.class/instance/tearDown.st
@@ -1,0 +1,4 @@
+running
+tearDown
+
+	window delete

--- a/packages/MarkdownEditor-Tests.package/MarkdownEditorTests.class/instance/testMenuOpenCommand.st
+++ b/packages/MarkdownEditor-Tests.package/MarkdownEditorTests.class/instance/testMenuOpenCommand.st
@@ -1,7 +1,7 @@
 tests
 testMenuOpenCommand
 
-	self
-		assert: [TheWorldMenu registeredOpenCommands
+	TheWorldMenu unregisterOpenCommand: 'Markdown Editor'.
+	MarkdownEditor initialize.
+	self assert: [TheWorldMenu registeredOpenCommands
 					includes: {'Markdown Editor'. {MarkdownEditor. #open}}]
-		description: 'The menu should have a command to open the markdown editor.'

--- a/packages/MarkdownEditor-Tests.package/MarkdownEditorTests.class/instance/testTextPersistence.st
+++ b/packages/MarkdownEditor-Tests.package/MarkdownEditorTests.class/instance/testTextPersistence.st
@@ -1,9 +1,9 @@
 tests
 testTextPersistence
-	
+
 	| editor |
 	editor := toolbuilder build: (MarkdownEditor new buildEditorWith: toolbuilder).
-	editor setText: 'I like trains.'.
-	editor accept.
+	editor
+		replaceSelectionWith: 'I like trains.';
+		accept.
 	self assert: (editor text = 'I like trains.')
-		

--- a/packages/MarkdownEditor-Tests.package/MarkdownEditorTests.class/instance/testWindowCreation.st
+++ b/packages/MarkdownEditor-Tests.package/MarkdownEditorTests.class/instance/testWindowCreation.st
@@ -1,10 +1,4 @@
 tests
 testWindowCreation
 
-	self closeMarkdownEditorWindows.
-	MarkdownEditor open.
-	self
-		assert: self markdownWindows size
-		equals: 1
-		description: 'The markdown editor should open in a window.';
-		closeMarkdownEditorWindows
+	self assert: (World submorphs includes: window)

--- a/packages/MarkdownEditor-Tests.package/MarkdownEditorTests.class/instance/testWindowLabel.st
+++ b/packages/MarkdownEditor-Tests.package/MarkdownEditorTests.class/instance/testWindowLabel.st
@@ -1,0 +1,6 @@
+tests
+testWindowLabel
+
+	self
+		assert: 'Markdown Editor'
+		equals: window label

--- a/packages/MarkdownEditor-Tests.package/MarkdownEditorTests.class/methodProperties.json
+++ b/packages/MarkdownEditor-Tests.package/MarkdownEditorTests.class/methodProperties.json
@@ -2,11 +2,11 @@
 	"class" : {
 		 },
 	"instance" : {
-		"closeMarkdownEditorWindows" : "jst 4/26/2019 21:39",
-		"markdownWindows" : "jst 4/26/2019 21:38",
-		"setUp" : "kgr 4/29/2019 13:43",
+		"setUp" : "jst 5/11/2019 19:40",
+		"tearDown" : "jst 5/11/2019 19:40",
 		"testBuildEditorWithReturnsSpec" : "kgr 4/29/2019 14:13",
 		"testBuildWithReturnsWindow" : "kgr 4/29/2019 13:44",
-		"testMenuOpenCommand" : "kgr 4/28/2019 17:56",
-		"testTextPersistence" : "kgr 4/29/2019 14:20",
-		"testWindowCreation" : "jst 4/26/2019 21:38" } }
+		"testMenuOpenCommand" : "jst 5/11/2019 19:56",
+		"testTextPersistence" : "jst 5/11/2019 20:16",
+		"testWindowCreation" : "jst 5/11/2019 19:49",
+		"testWindowLabel" : "jst 5/11/2019 19:50" } }

--- a/packages/MarkdownEditor-Tests.package/MarkdownEditorTests.class/properties.json
+++ b/packages/MarkdownEditor-Tests.package/MarkdownEditorTests.class/properties.json
@@ -6,7 +6,8 @@
 		 ],
 	"commentStamp" : "",
 	"instvars" : [
-		"toolbuilder" ],
+		"toolbuilder",
+		"window" ],
 	"name" : "MarkdownEditorTests",
 	"pools" : [
 		 ],


### PR DESCRIPTION
I go a bit annoyed that the combination of active development + Auto TDD closes the Markdown Editor window so I refactored the tests a bit.

- Close all created windows, even when tests fail
- Keep windows which are opened by the user
- Split tests for window creation and label checking
- Unregister open command and reinitialize it before testing it
- Properly simulate text editing with `replaceSelectionWith:`