### PR TITLE
Editorconfig and Trunk-Testing

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*.st]
+tab_width = 4
+insert_final_newline = false

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,11 @@ os:
   - osx
 
 smalltalk:
+  - Squeak-trunk
   - Squeak-5.2
   - Squeak-5.1
   - Squeak-5.0
+
+matrix:
+  allow_failures:
+    - smalltalk: Squeak-trunk


### PR DESCRIPTION
This halves the tab width on GitHub, giving almost the same feeling like in the image. It also removes the "no newline" warning.

Trunk testing is recommended, but I just add it as an allowed failure as it is slightly more unstable.