### PR TITLE
Removes font size glitch

### DIFF
--- a/packages/MarkdownEditor-Core.package/MarkdownHeading.class/instance/textAttribute.st
+++ b/packages/MarkdownEditor-Core.package/MarkdownHeading.class/instance/textAttribute.st
@@ -1,4 +1,4 @@
 accessing
 textAttribute
 	
-	^ TextFontReference toFont: self font
+	^ UnextendableTextFontReference toFont: self font

--- a/packages/MarkdownEditor-Core.package/MarkdownHeading.class/methodProperties.json
+++ b/packages/MarkdownEditor-Core.package/MarkdownHeading.class/methodProperties.json
@@ -10,4 +10,4 @@
 		"isInterruptedBy:" : "jst 6/10/2019 12:10",
 		"level" : "jst 5/13/2019 15:24",
 		"prefix" : "jst 5/13/2019 15:29",
-		"textAttribute" : "jko 6/25/2019 20:40" } }
+		"textAttribute" : "fgo 6/26/2019 22:38" } }

--- a/packages/MarkdownEditor-Core.package/UnextendableTextFontReference.class/README.md
+++ b/packages/MarkdownEditor-Core.package/UnextendableTextFontReference.class/README.md
@@ -1,0 +1,1 @@
+I am a TextFontReference but I am not extendable. Therefore I do not cause glitches when being used in environments with different font sizes.

--- a/packages/MarkdownEditor-Core.package/UnextendableTextFontReference.class/instance/mayBeExtended.st
+++ b/packages/MarkdownEditor-Core.package/UnextendableTextFontReference.class/instance/mayBeExtended.st
@@ -1,0 +1,4 @@
+testing
+mayBeExtended
+
+	^ false

--- a/packages/MarkdownEditor-Core.package/UnextendableTextFontReference.class/methodProperties.json
+++ b/packages/MarkdownEditor-Core.package/UnextendableTextFontReference.class/methodProperties.json
@@ -1,0 +1,5 @@
+{
+	"class" : {
+		 },
+	"instance" : {
+		"mayBeExtended" : "fgo 6/26/2019 22:34" } }

--- a/packages/MarkdownEditor-Core.package/UnextendableTextFontReference.class/properties.json
+++ b/packages/MarkdownEditor-Core.package/UnextendableTextFontReference.class/properties.json
@@ -1,0 +1,14 @@
+{
+	"category" : "MarkdownEditor-Core",
+	"classinstvars" : [
+		 ],
+	"classvars" : [
+		 ],
+	"commentStamp" : "fgo 6/26/2019 22:40",
+	"instvars" : [
+		 ],
+	"name" : "UnextendableTextFontReference",
+	"pools" : [
+		 ],
+	"super" : "TextFontReference",
+	"type" : "normal" }

--- a/packages/MarkdownEditor-Tests.package/MarkdownBlockTextStylerTest.class/instance/headingFontSized..st
+++ b/packages/MarkdownEditor-Tests.package/MarkdownBlockTextStylerTest.class/instance/headingFontSized..st
@@ -1,7 +1,7 @@
 accessing
 headingFontSized: pointSize
 
-	^ TextFontReference 
+	^ UnextendableTextFontReference 
 		toFont: (TTCFont
 			familyName: 'BitstreamVeraSans'
 			pointSize: pointSize

--- a/packages/MarkdownEditor-Tests.package/MarkdownBlockTextStylerTest.class/methodProperties.json
+++ b/packages/MarkdownEditor-Tests.package/MarkdownBlockTextStylerTest.class/methodProperties.json
@@ -5,7 +5,7 @@
 		"assert:isParsedStructureOf:" : "jko 6/22/2019 17:37",
 		"assert:parsesToRuns:values:" : "jko 6/22/2019 17:37",
 		"attributesOf:" : "jst 5/11/2019 19:05",
-		"headingFontSized:" : "lpf 6/14/2019 15:48",
+		"headingFontSized:" : "fgo 6/26/2019 22:35",
 		"setUp" : "jko 6/22/2019 17:37",
 		"testBlockStructureCodeBlock" : "jst 6/7/2019 14:47",
 		"testBlockStructureCodeBlockFollowedByParagraph" : "jst 6/10/2019 11:31",

--- a/packages/MarkdownEditor-Tests.package/MarkdownHeadingsTest.class/instance/headingFontSized..st
+++ b/packages/MarkdownEditor-Tests.package/MarkdownHeadingsTest.class/instance/headingFontSized..st
@@ -1,7 +1,7 @@
 accessing
 headingFontSized: pointSize
 
-	^ TextFontReference 
+	^ UnextendableTextFontReference 
 		toFont: (TTCFont
 			familyName: 'BitstreamVeraSans'
 			pointSize: pointSize

--- a/packages/MarkdownEditor-Tests.package/MarkdownHeadingsTest.class/methodProperties.json
+++ b/packages/MarkdownEditor-Tests.package/MarkdownHeadingsTest.class/methodProperties.json
@@ -4,7 +4,7 @@
 	"instance" : {
 		"assert:asTextHasAttributes:" : "jst 5/13/2019 16:01",
 		"assert:hasAttributes:" : "jst 5/13/2019 15:46",
-		"headingFontSized:" : "lpf 6/14/2019 15:48",
+		"headingFontSized:" : "fgo 6/26/2019 22:35",
 		"testConvertingToTextUsesInlineStyler" : "fgo 6/23/2019 09:31",
 		"testFindLevelOfHeadingLevels1To6" : "lpf 6/17/2019 19:07",
 		"testMatch1To3Indentations" : "lpf 6/14/2019 16:29",

--- a/packages/MarkdownEditor-Tests.package/MarkdownMockTextStyler.class/properties.json
+++ b/packages/MarkdownEditor-Tests.package/MarkdownMockTextStyler.class/properties.json
@@ -4,7 +4,7 @@
 		 ],
 	"classvars" : [
 		 ],
-	"commentStamp" : "jst 6/7/2019 15:47",
+	"commentStamp" : "",
 	"instvars" : [
 		"memorizedStylingRequest" ],
 	"name" : "MarkdownMockTextStyler",

--- a/packages/MarkdownEditor-Tests.package/UnextendableTextFontReferenceTest.class/instance/testMayNotBeExtended.st
+++ b/packages/MarkdownEditor-Tests.package/UnextendableTextFontReferenceTest.class/instance/testMayNotBeExtended.st
@@ -1,0 +1,6 @@
+tests
+testMayNotBeExtended
+
+	| fontReference |
+	fontReference :=UnextendableTextFontReference new.
+	self deny: fontReference mayBeExtended

--- a/packages/MarkdownEditor-Tests.package/UnextendableTextFontReferenceTest.class/instance/testMayNotBeExtended.st
+++ b/packages/MarkdownEditor-Tests.package/UnextendableTextFontReferenceTest.class/instance/testMayNotBeExtended.st
@@ -2,5 +2,5 @@ tests
 testMayNotBeExtended
 
 	| fontReference |
-	fontReference :=UnextendableTextFontReference new.
+	fontReference := UnextendableTextFontReference new.
 	self deny: fontReference mayBeExtended

--- a/packages/MarkdownEditor-Tests.package/UnextendableTextFontReferenceTest.class/methodProperties.json
+++ b/packages/MarkdownEditor-Tests.package/UnextendableTextFontReferenceTest.class/methodProperties.json
@@ -1,0 +1,5 @@
+{
+	"class" : {
+		 },
+	"instance" : {
+		"testMayNotBeExtended" : "fgo 6/27/2019 08:50" } }

--- a/packages/MarkdownEditor-Tests.package/UnextendableTextFontReferenceTest.class/methodProperties.json
+++ b/packages/MarkdownEditor-Tests.package/UnextendableTextFontReferenceTest.class/methodProperties.json
@@ -2,4 +2,4 @@
 	"class" : {
 		 },
 	"instance" : {
-		"testMayNotBeExtended" : "fgo 6/27/2019 08:50" } }
+		"testMayNotBeExtended" : "fgo 6/27/2019 08:52" } }

--- a/packages/MarkdownEditor-Tests.package/UnextendableTextFontReferenceTest.class/properties.json
+++ b/packages/MarkdownEditor-Tests.package/UnextendableTextFontReferenceTest.class/properties.json
@@ -1,0 +1,14 @@
+{
+	"category" : "MarkdownEditor-Tests",
+	"classinstvars" : [
+		 ],
+	"classvars" : [
+		 ],
+	"commentStamp" : "",
+	"instvars" : [
+		 ],
+	"name" : "UnextendableTextFontReferenceTest",
+	"pools" : [
+		 ],
+	"super" : "TestCase",
+	"type" : "normal" }


### PR DESCRIPTION
- Fixes #6
- Introduces `UnextendableTextFontReference` which tells the editor window to not use the current font size as next guess. Instead, the standard font is used until the Markdown stylers did finish their work.

I think that it is very hard to write a proper test for this. But testing manually showed, that I cannot reproduce the defect from #6 anymore.

Do you have a better name for `UnextendableTextFontReference`?