### PR TITLE
Unsupport Squeak 5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ smalltalk:
   - Squeak-trunk
   - Squeak-5.2
   - Squeak-5.1
-  - Squeak-5.0
 
 matrix:
   allow_failures:

--- a/packages/BaselineOfMarkdownEditor.package/BaselineOfMarkdownEditor.class/instance/baseline..st
+++ b/packages/BaselineOfMarkdownEditor.package/BaselineOfMarkdownEditor.class/instance/baseline..st
@@ -5,12 +5,7 @@ baseline: spec
 		for: #'common'
 		do: [
 			spec
-				package: 'VB-Regex' with: [
-					spec repository: 'http://www.squeaksource.com/Regex'].
-			spec
-				package: 'MarkdownEditor-Core' with: [
-					(#('Squeak5.0') includes: Smalltalk version)
-						ifTrue: [spec requires: #('VB-Regex')]];
+				package: 'MarkdownEditor-Core';
 				package: 'MarkdownEditor-Tests' with: [spec requires: #('MarkdownEditor-Core')];
 				yourself.
 			spec

--- a/packages/MarkdownEditor-Tests.package/MarkdownEditorTest.class/instance/expectedFailures.st
+++ b/packages/MarkdownEditor-Tests.package/MarkdownEditorTest.class/instance/expectedFailures.st
@@ -1,7 +1,0 @@
-running
-expectedFailures
-
-	^ Smalltalk version = 'Squeak5.0'
-		ifTrue: [#(testApplyingThemeDoesNotThrowErrorForBlockStyling
-					testApplyingThemeDoesNotThrowErrorForInlineStyling)]
-		ifFalse: [#()]

--- a/packages/MarkdownEditor-Tests.package/MarkdownEditorTest.class/methodProperties.json
+++ b/packages/MarkdownEditor-Tests.package/MarkdownEditorTest.class/methodProperties.json
@@ -2,11 +2,10 @@
 	"class" : {
 		 },
 	"instance" : {
-		"expectedFailures" : "jst 6/29/2019 14:53",
 		"setUp" : "jst 5/11/2019 19:40",
 		"tearDown" : "jst 5/11/2019 19:40",
 		"testApplyingThemeDoesNotThrowErrorForBlockStyling" : "jst 6/29/2019 14:39",
-		"testApplyingThemeDoesNotThrowErrorForIniineStyling" : "jst 6/29/2019 11:55",
+		"testApplyingThemeDoesNotThrowErrorForInlineStyling" : " 7/1/2019 13:56:32",
 		"testBuildingEditorReturnsWindow" : "lpf 6/13/2019 15:24",
 		"testBuildingEditorTextMorphReturnsSpec" : "lpf 6/13/2019 15:29",
 		"testMenuOpenCommand" : "jst 5/11/2019 19:56",

--- a/packages/MarkdownEditor-Tests.package/MarkdownMockTextStyler.class/properties.json
+++ b/packages/MarkdownEditor-Tests.package/MarkdownMockTextStyler.class/properties.json
@@ -4,7 +4,7 @@
 		 ],
 	"classvars" : [
 		 ],
-	"commentStamp" : "jst 6/7/2019 15:47",
+	"commentStamp" : "",
 	"instvars" : [
 		"memorizedStylingRequest" ],
 	"name" : "MarkdownMockTextStyler",


### PR DESCRIPTION
The changes in this PR remove support for Squeak 5.0. Therefore we were able to remove the `VB-Regex` package from the dependencies.