### PR TITLE
Fix Coverage by excluding methods

### DIFF
--- a/.smalltalk.ston
+++ b/.smalltalk.ston
@@ -12,7 +12,10 @@ SmalltalkCISpec {
   ],
   #testing : {
     #coverage : {
-      #packages : [ 'MarkdownEditor-Core', 'MarkdownEditor-Utilities' ]
+      #packages : [ 'MarkdownEditor-Core', 'MarkdownEditor-Utilities' ],
+      #exclude: {
+        #categories: [ 'open / save - I/O' ]
+      }
     },
     #exclude : {
       #classes : [ #MarkdownEditorLintTest ]

--- a/.smalltalk.ston
+++ b/.smalltalk.ston
@@ -18,7 +18,8 @@ SmalltalkCISpec {
       }
     },
     #exclude : {
-      #classes : [ #MarkdownEditorLintTest ]
+      #classes : [ #MarkdownEditorLintTest ],
+      #categories: [ 'open / save - I/O' ]
     }
   }
 }

--- a/packages/MarkdownEditor-Core.package/MarkdownEditor.class/instance/openFileDialog.st
+++ b/packages/MarkdownEditor-Core.package/MarkdownEditor.class/instance/openFileDialog.st
@@ -1,4 +1,4 @@
-open / save
+open / save - I/O
 openFileDialog
 
 	self openFile: FileChooser new

--- a/packages/MarkdownEditor-Core.package/MarkdownEditor.class/instance/saveAsFile..st
+++ b/packages/MarkdownEditor-Core.package/MarkdownEditor.class/instance/saveAsFile..st
@@ -1,4 +1,4 @@
-open / save
+open / save - I/O
 saveAsFile: aFilePath
 
 	aFilePath ifNotNil: [

--- a/packages/MarkdownEditor-Core.package/MarkdownEditor.class/instance/saveAsFileDialog.st
+++ b/packages/MarkdownEditor-Core.package/MarkdownEditor.class/instance/saveAsFileDialog.st
@@ -1,4 +1,4 @@
-open / save
+open / save - I/O
 saveAsFileDialog
 
 	self saveAsFile: (FileSaverDialog openOnInitialFilename: self defaultFilename)

--- a/packages/MarkdownEditor-Core.package/MarkdownEditor.class/instance/saveText.st
+++ b/packages/MarkdownEditor-Core.package/MarkdownEditor.class/instance/saveText.st
@@ -1,4 +1,4 @@
-open / save
+open / save - I/O
 saveText
 
 	self currentFilePath isEmpty


### PR DESCRIPTION
The methods to exclude have to be in a specific categorie. This is currently called `'open / save - I/O'`.